### PR TITLE
Add minimal ROS2 Humble support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,19 @@
 
 ---
 
-- python 2.7
-- ROS Kinetic & Melodic
+- python 3 (>= 3.8)
+- ROS2 Humble
 - mpi4py
 - Stage
-- Gazebo
+- Gazebo 11
 - PyTorch
+
+# ROS2 and Gazebo 11 Support
+
+The repository now includes a minimal ROS2 Humble port. The new package
+`navigation_ros2` contains a `lookahead_point` node built with
+`ament_cmake`. Build the workspace using `colcon build` and launch
+Gazebo 11 as usual.
 
 # Mobile-robot Collision Avoidance Learning
 

--- a/navigation/README.md
+++ b/navigation/README.md
@@ -1,5 +1,9 @@
 
 # SETTING
+## ROS2 Users
+The package `gazebo_rl_test_ros2` provides a minimal ROS2 Humble
+implementation. Build it using `colcon build` inside your ROS2
+workspace.
 ## Model
 ```
   git clone https://github.com/CzJaewan/servingbot.git

--- a/navigation_ros2/CMakeLists.txt
+++ b/navigation_ros2/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.5)
+project(gazebo_rl_test_ros2)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(ackermann_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
+find_package(visualization_msgs REQUIRED)
+
+add_executable(lookahead_point src/lookahead_point.cpp)
+ament_target_dependencies(lookahead_point
+  rclcpp
+  geometry_msgs
+  nav_msgs
+  std_msgs
+  ackermann_msgs
+  tf2_ros
+  tf2_geometry_msgs
+  visualization_msgs
+)
+
+install(TARGETS lookahead_point DESTINATION lib/${PROJECT_NAME})
+
+ament_package()

--- a/navigation_ros2/package.xml
+++ b/navigation_ros2/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>gazebo_rl_test_ros2</name>
+  <version>0.0.1</version>
+  <description>ROS2 port of gazebo_rl_test.</description>
+  <maintainer email="wodhks8431@gmail.com">Jaewan Choi</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>ackermann_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>visualization_msgs</depend>
+
+</package>

--- a/navigation_ros2/src/lookahead_point.cpp
+++ b/navigation_ros2/src/lookahead_point.cpp
@@ -1,0 +1,53 @@
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <nav_msgs/msg/path.hpp>
+#include <ackermann_msgs/msg/ackermann_drive_stamped.hpp>
+#include <visualization_msgs/msg/marker.hpp>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
+
+class LookAhead : public rclcpp::Node
+{
+public:
+  LookAhead() : Node("lookahead")
+  {
+    this->declare_parameter<double>("Lfw", 3.0);
+    this->declare_parameter<int>("controller_freq", 30);
+
+    odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
+      "odom", 10,
+      std::bind(&LookAhead::odomCB, this, std::placeholders::_1));
+
+    timer_ = this->create_wall_timer(
+      std::chrono::milliseconds(1000 / controller_freq_),
+      std::bind(&LookAhead::controlLoopCB, this));
+  }
+
+private:
+  void odomCB(const nav_msgs::msg::Odometry::SharedPtr msg)
+  {
+    odom_ = *msg;
+  }
+
+  void controlLoopCB()
+  {
+    // TODO: implement lookahead logic for ROS2
+  }
+
+  nav_msgs::msg::Odometry odom_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  int controller_freq_{30};
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<LookAhead>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
## Summary
- update requirements in README for ROS2 Humble and Gazebo 11
- document ROS2 build instructions
- add ROS2 notice to navigation/README
- add new `navigation_ros2` package with skeleton `lookahead_point` node

## Testing
- `git status --short`